### PR TITLE
handle disconnected server state

### DIFF
--- a/http.promise.js
+++ b/http.promise.js
@@ -57,7 +57,8 @@ module.exports = (function wrapRequest(request, defaultOpts){
     opts.method = opts.method.toUpperCase();
     return new Promise(function HTTP_PROMISE(resolve, reject) {
       request(opts, function HTTP_RESPONSE(error, response, body) {
-        if (error) {
+        // statusCode 0: disconnected state
+        if (error || (response && response.statusCode === 0)) {
           error.options = opts;
           error.statusCode = 0;
           error.title = 'Invalid Request';


### PR DESCRIPTION
When in a disconnected state, a `statusCode` of `0` is returned, but the `error` object is null causing the current version to act as if the request were successful.

This should patch said issue.
