### PR TITLE
handle invalid connection state

### DIFF
--- a/http.promise.js
+++ b/http.promise.js
@@ -63,7 +63,7 @@ module.exports = (function wrapRequest(request, defaultOpts){
           error.title = 'Invalid Request';
           error.summary = 'failed to perform HTTP request';
           reject(error);
-        } else if (opts.error && response.statusCode >= 400) {
+        } else if (opts.error && (response.statusCode === 0 || response.statusCode >= 400)) {
           var statusCode = response.statusCode;
           var HTTPErr = HTTP.error.hasOwnProperty(statusCode)
                       ? HTTP.error[statusCode]


### PR DESCRIPTION
Okay. Take 2 at this pull request. We're using `http-as-promised` in conjunction with `browserify` and running in to an issue when getting `CONNECTION_REFUSED` exceptions (ie: dropped local connection or down server) where the promise is not being rejected.

As it turns out, this is because the `error` provided is `null` while the `statusCode` of the response indicating failure is `0`.

I made several passes at a unit test for this case, but nock doesn't want to let you set the response code to `0` - it's admittedly a non-standard response code, but nonetheless the one provided when a connection issue exists.
