### PR TITLE
Fix for CVE-2017-15010

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "4"
+  - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "lts/*"
+  - "node"
+
 script: npm run test-cov

--- a/http.error.js
+++ b/http.error.js
@@ -49,8 +49,9 @@ HTTPError.prototype.toJSON = errorToJSON;
 
 function errorToJSON(){
   var error = {};
-  for (var k in this)
+  for (var k in this) {
     error[k] = this[k];
+  }
   return error;
 }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "create-error": "^0.3.1",
-    "request": "^2.60.0"
+    "request": "^2.83.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "url": "http://github.com/jcready/http-as-promised/issues"
   },
   "license": "MIT",
-  "engines": [
-    "node >= 0.10.0"
-  ],
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "test": "mocha test && eslint ./",
     "test-cov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",


### PR DESCRIPTION
@jcready Can you review my PR?

If it looks good, can you bump the **major** version and publish it?

Breaking changes:
Supports Nodejs v4 or higher.  This is required since request v2.83.0 has the [same requirement](https://github.com/request/request/blob/master/package.json#L21).

References to security vulnerability:
https://snyk.io/vuln/npm:tough-cookie:20170905
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15010

Thanks!